### PR TITLE
Total and active AI counts only

### DIFF
--- a/addon/ark_asm/postinit.sqf
+++ b/addon/ark_asm/postinit.sqf
@@ -22,8 +22,8 @@ ark_asm_fnc_startMonitoring = {
 
 ark_asm_fnc_monitor = {
     private _playerCount = count (allUnits select { alive _x && {isPlayer _x} });
-    private _localAiCount = count (allUnits select { alive _x && {simulationEnabled _x} && {!isPlayer _x} && {local _x} });
-    private _remoteAiCount = count (allUnits select { alive _x && {simulationEnabled _x} && {!isPlayer _x} && {!local _x} });
+    private _totalAiCount = count (allUnits select { alive _x && {!isPlayer _x} });
+    private _activeAiCount = count (allUnits select { alive _x && {simulationEnabled _x} && {!isPlayer _x} });
     private _entityCount = count (entities [[], [], true, false]);
     private _snapsot = [
         "profileName", profileName,
@@ -36,8 +36,8 @@ ark_asm_fnc_monitor = {
         "fpsMin", diag_fpsMin,
         "cps", [] call ark_asm_fnc_getCurrentCps,
         "playerCount", _playerCount,
-        "localAiCount", _localAiCount,
-        "remoteAiCount", _remoteAiCount,
+        "totalAiCount", _totalAiCount,
+        "activeAiCount", _activeAiCount,
         "entityCount", _entityCount
     ];
     "ark_asm_extension" callExtension ["mission.snapshot", _snapsot];

--- a/web/src/client/Config.js
+++ b/web/src/client/Config.js
@@ -19,13 +19,13 @@ const series = {
             maxValue: 400,
             color: "#3EB2F2"
         },
-        localAiCount: {
-            label: "Local AI",
+        totalAiCount: {
+            label: "Total AI",
             maxValue: 1000,
             color: "#8ECFFF"
         },
-        remoteAiCount: {
-            label: "Remote AI",
+        activeAiCount: {
+            label: "Active AI",
             maxValue: 1000,
             color: "#C9E3FF"
         },

--- a/web/src/server/Snapshot.js
+++ b/web/src/server/Snapshot.js
@@ -1,7 +1,7 @@
 const Server = require("./Server");
 
 function parseSnapshot(rawSnapshot) {
-    ["missionStartTime", "tickTime", "fps", "fpsMin", "cps", "playerCount", "localAiCount", "remoteAiCount", "entityCount"].forEach(prop => {
+    ["missionStartTime", "tickTime", "fps", "fpsMin", "cps", "playerCount", "totalAiCount", "activeAiCount", "entityCount"].forEach(prop => {
         rawSnapshot[prop] = parseFloat(rawSnapshot[prop]);
     });
     rawSnapshot.isServer = rawSnapshot && rawSnapshot === "true";


### PR DESCRIPTION
This repurposes the the local/remote to give more useful information.

I know we added these originally to check when AI was transferring from the server to the HC but seeing as we've never run HCs reliably in A3 I'd rather have these two metrics available and not keep a metric we don't use.